### PR TITLE
Fix estimated KMS for a given charged kWh

### DIFF
--- a/custom_components/v2c_trydan/sensor.py
+++ b/custom_components/v2c_trydan/sensor.py
@@ -301,7 +301,7 @@ class ChargeKmSensor(CoordinatorEntity, SensorEntity):
     @property
     def state(self):
         charge_energy = self.coordinator.data.get("ChargeEnergy", 0)
-        charge_km = charge_energy / ((self._kwh_per_100km / 100) * 0.8)
+        charge_km = charge_energy * 0.8 / ((self._kwh_per_100km / 100))
         return round(charge_km, 2)
 
     @property


### PR DESCRIPTION
Loss factor was in the wrong position in the equation, making the car to consume less instead of more. I exemplify this below:

### Example data:

 - Car consumption: 20 kWh/100
 -  Charged energy: 10 kWh

### With the current approach:

Estimated kms: `10 / ((20 / 100) * 0.8)` = 62.5 kms

It's easy to see that, given the example values and assuming a 0% loss, we could only drive 50 kms. Nonetheless the current approach returns even more distance, which is impossible.

### With the proposed approach:

Estimated kms: `10 * 0.8 / ((20 / 100))` = 40 kms

With the proposed approach, and assuming an energy loss of 20% (I guess this is what you meant with `0.8`), we could drive 40 kms, which makes sense.


Thank you for your amazing HA integration. 

Let me know your thoughts 🙂 
